### PR TITLE
Display empty list message

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -12,15 +12,30 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   int _currentIndex = 0;
 
-  final _pages = const [ItemsListPage(), ScanPage()];
+  final GlobalKey<_ItemsListPageState> _listKey = GlobalKey<_ItemsListPageState>();
+  late final List<Widget> _pages;
 
   final _titles = const ['Lista', 'Escanear'];
+
+  @override
+  void initState() {
+    super.initState();
+    _pages = [ItemsListPage(key: _listKey), const ScanPage()];
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(_titles[_currentIndex])),
       body: _pages[_currentIndex],
+      floatingActionButton: _currentIndex == 0
+          ? FloatingActionButton(
+              onPressed: () {
+                _listKey.currentState?.showAddItemDialog(context);
+              },
+              child: const Icon(Icons.add),
+            )
+          : null,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,
         onTap: (index) {

--- a/lib/pages/items_list_page.dart
+++ b/lib/pages/items_list_page.dart
@@ -20,24 +20,67 @@ class _ItemsListPageState extends State<ItemsListPage> {
 
   Future<void> _loadItems() async {
     final items = await ItemsDatabase.instance.readAll();
-    if (items.isEmpty) {
-      for (var i = 1; i <= 5; i++) {
-        await ItemsDatabase.instance.create(Item(name: 'Produto $i'));
-      }
-    }
-    final updated = await ItemsDatabase.instance.readAll();
     setState(() {
-      _items = updated;
+      _items = items;
     });
+  }
+
+  Future<void> showAddItemDialog(BuildContext context) async {
+    final controller = TextEditingController();
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Adicionar Item'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(labelText: 'Nome do produto'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final name = controller.text.trim();
+                if (name.isNotEmpty) {
+                  await ItemsDatabase.instance.create(Item(name: name));
+                  Navigator.pop(context);
+                  _loadItems();
+                }
+              },
+              child: const Text('Adicionar'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    if (_items.isEmpty) {
+      return const Center(
+        child: Text('Lista vazia, adicione ou escaneie um produto.'),
+      );
+    }
+
     return ListView.builder(
       itemCount: _items.length,
       itemBuilder: (context, index) {
         final item = _items[index];
         return ListTile(
+          leading: Checkbox(
+            value: item.purchased,
+            onChanged: (value) async {
+              final updated = item.copyWith(purchased: value ?? false);
+              await ItemsDatabase.instance.update(updated);
+              setState(() {
+                _items[index] = updated;
+              });
+            },
+          ),
           title: Text(item.name),
           trailing: const Icon(Icons.chevron_right),
           onTap: () {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,12 +4,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shopscan/main.dart';
 
 void main() {
-  testWidgets('Lista de itens exibida', (WidgetTester tester) async {
+  testWidgets('Mensagem de lista vazia exibida', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
 
-    expect(find.text('Produto 1'), findsOneWidget);
+    expect(find.text('Lista vazia, adicione ou escaneie um produto.'),
+        findsOneWidget);
     expect(find.text('Tela de Câmera (em breve)'), findsNothing);
+
+    expect(find.byIcon(Icons.add), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Adicionar Item'), findsOneWidget);
+    await tester.tap(find.text('Cancelar'));
+    await tester.pumpAndSettle();
 
     await tester.tap(find.byIcon(Icons.camera_alt));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- show "Lista vazia" message when there are no items
- add manual item creation dialog via a floating action button
- allow marking items as purchased and persist state
- update widget test for new empty state

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688245ffea00832ca06a2d1b02c32b24